### PR TITLE
Changed aria2c installation detection

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,6 @@
 MIT Licence
 
-Copyright (c) 2025 Licon4812
+Copyright (c) 2025 Australian Web Connection
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Aria2Extension/Package.appxmanifest
+++ b/src/Aria2Extension/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="23610AlickolliSoftware.Aria2ExtensionforCommandPal"
     Publisher="CN=5CECD841-CF4E-45AF-B443-573F4A3614A0"
-    Version="0.0.1.0" />
+    Version="0.0.2.0" />
   <!-- When you're ready to publish your extension, you'll need to change the
        Publisher= to match your own identity -->
 

--- a/src/Aria2Extension/Pages/Aria2ExtensionPage.cs
+++ b/src/Aria2Extension/Pages/Aria2ExtensionPage.cs
@@ -39,24 +39,25 @@ internal sealed partial class Aria2ExtensionPage : ListPage
 
     internal static bool IsAria2Installed()
     {
-        var startInfo = new ProcessStartInfo
+        try
         {
-            FileName = "winget",
-            Arguments = "list aria2.aria2",
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
+            using var process = new Process();
+            process.StartInfo = new ProcessStartInfo
+            {
+                FileName = "aria2c",
+                Arguments = "--version",
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
 
-        using var process = new Process();
-        process.StartInfo = startInfo;
-        process.Start();
-        var output = process.StandardOutput.ReadToEnd();
-        var error = process.StandardError.ReadToEnd();
-        process.WaitForExit();
-
-        // Check if the output contains "aria2.aria2"
-        return output.Contains("aria2.aria2");
+            process.Start();
+            process.WaitForExit();
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
This pull request includes several important changes to the `Aria2Extension` project, including updates to licensing information, versioning, and error handling improvements. Below is a summary of the most significant changes:

### Licensing Update:
* `LICENCE`: Updated the copyright holder from "Licon4812" to "Australian Web Connection". (F5a20c61L1)

### Versioning:
* `src/Aria2Extension/Package.appxmanifest`: Incremented the version number from "0.0.1.0" to "0.0.2.0". (F492e3d2L11)

### Error Handling Improvements:
* `src/Aria2Extension/Pages/Aria2ExtensionPage.cs`: Improved the `IsAria2Installed` method by using a `try-catch` block and updating the command to check for `aria2c` version instead of listing `aria2.aria2`. This change enhances the reliability of the method by ensuring it correctly handles errors and checks for the presence of the `aria2c` executable. (Fa0d2424L39)